### PR TITLE
Make submit delegated handler behave like knockout

### DIFF
--- a/src/knockout-delegatedEvents.js
+++ b/src/knockout-delegatedEvents.js
@@ -67,7 +67,14 @@
 
                 //execute the action as KO normally would
                 if (action) {
-                    result = action.call(owner, data, event);
+                    // if the event is a submit event, we want to just pass
+                    // the form element, and set the context to 'this'.
+                    // This matches the knockout behaviour for submit bindings.
+                    if (eventName === 'submit') {
+                      result = action.call(data, event.target);
+                    } else {
+                      result = action.call(owner, data, event);
+                    }
 
                     //prevent default action, if handler does not return true
                     if (result !== true) {


### PR DESCRIPTION
References #5 (https://github.com/rniemeyer/knockout-delegatedEvents/issues/5).

Knockout's submit binding handler is subtly different to the other event handlers.

Instead of the root element being `this`, and getting two arguments `data`, and `event`, it sets `this` to the current bindingContext value, and passes a single argument that is the form element that is bound.

This patch replicates that behaviour.
